### PR TITLE
Add cash payment purpose capture to vouchers

### DIFF
--- a/pages/reports/PartyLedgerReport.tsx
+++ b/pages/reports/PartyLedgerReport.tsx
@@ -31,12 +31,16 @@ const PartyLedgerReport: React.FC = () => {
             let narrative: string = tx.type;
 
             if (tx.type === TransactionType.Payment) {
+                const cashDetails = [tx.cash_payment_purpose, tx.cash_description?.trim()].filter(Boolean).join(' – ');
                 if (tx.payment_type === 'Paid') {
                     debit = tx.amount_received;
                     narrative = 'Payment (Paid)';
                 } else { // Received
                     credit = tx.amount_received;
                     narrative = 'Payment (Received)';
+                }
+                if (cashDetails) {
+                    narrative += ` - ${cashDetails}`;
                 }
             } else {
                 const party = parties.find(p => p.id === tx.party_id);

--- a/types.ts
+++ b/types.ts
@@ -53,6 +53,14 @@ export enum PaymentType {
   Received = 'Received',
 }
 
+export enum CashPaymentPurpose {
+  Salary = 'Salary',
+  LorryFreight = 'Lorry Freight',
+  NSG = 'NSG',
+  Pada = 'Pada',
+  Other = 'Other',
+}
+
 export enum RateUnit {
   per_kg = 'per_kg',
   per_quintal = 'per_quintal',
@@ -127,6 +135,8 @@ export interface Transaction {
   // Payment Voucher specific fields
   payment_type?: PaymentType;
   bank_account_id?: string;
+  cash_payment_purpose?: CashPaymentPurpose;
+  cash_description?: string;
 }
 
 // For UI state and calculations, not persisted directly


### PR DESCRIPTION
## Summary
- add a CashPaymentPurpose enum and persist optional fields on transactions
- update the payment voucher UI to capture cash purpose, notes, and keep related inputs together
- include cash payment purpose/notes in the party ledger report narrative

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8bb1647988325abe147726ee66d3e