### PR TITLE
Add party search and transaction view to Party Master

### DIFF
--- a/hooks/useData.tsx
+++ b/hooks/useData.tsx
@@ -12,6 +12,7 @@ interface DataContextType {
   saveParty: (party: Party) => void;
   deleteParty: (partyId: string) => void;
   saveTransaction: (transaction: Transaction) => void;
+  deleteTransaction: (transactionId: string) => void;
   loading: boolean;
 }
 
@@ -103,8 +104,16 @@ export const DataProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     });
   }, []);
 
+  const deleteTransaction = useCallback((transactionId: string) => {
+    setTransactions(prev => {
+      const newTransactions = prev.filter(transaction => transaction.id !== transactionId);
+      setToStorage('transactions', newTransactions);
+      return newTransactions;
+    });
+  }, []);
+
   return (
-    <DataContext.Provider value={{ parties, crops, chargeHeads, bankAccounts, transactions, saveParty, deleteParty, saveTransaction, loading }}>
+    <DataContext.Provider value={{ parties, crops, chargeHeads, bankAccounts, transactions, saveParty, deleteParty, saveTransaction, deleteTransaction, loading }}>
       {children}
     </DataContext.Provider>
   );

--- a/pages/masters/PartyMaster.tsx
+++ b/pages/masters/PartyMaster.tsx
@@ -1,7 +1,10 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useData } from '../../hooks/useData';
 import { Party, PartyType } from '../../types';
 import { PencilIcon, TrashIcon } from '../../components/Icons';
+import { formatDate, formatINR } from '../../utils/formatters';
+import { calculateTransactionTotals } from '../../services/calculationService';
 
 const PartyModal: React.FC<{ party: Partial<Party> | null, onClose: () => void, onSave: (party: Party) => void }> = ({ party, onClose, onSave }) => {
     if (!party) return null;
@@ -92,9 +95,37 @@ const PartyModal: React.FC<{ party: Partial<Party> | null, onClose: () => void, 
 };
 
 const PartyMaster: React.FC = () => {
-    const { parties, saveParty, deleteParty, loading } = useData();
+    const { parties, transactions, chargeHeads, saveParty, deleteParty, deleteTransaction, loading } = useData();
+    const navigate = useNavigate();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [selectedParty, setSelectedParty] = useState<Partial<Party> | null>(null);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [activePartyId, setActivePartyId] = useState<string | null>(null);
+
+    const filteredParties = useMemo(() => {
+        if (!searchTerm.trim()) {
+            return parties;
+        }
+        const term = searchTerm.toLowerCase();
+        return parties.filter(party => {
+            const partyType = party.type || '';
+            return (
+                party.name.toLowerCase().includes(term) ||
+                party.mobile?.toLowerCase().includes(term) ||
+                partyType.toLowerCase().includes(term)
+            );
+        });
+    }, [parties, searchTerm]);
+
+    const activeParty = useMemo(
+        () => (activePartyId ? parties.find(party => party.id === activePartyId) ?? null : null),
+        [activePartyId, parties]
+    );
+
+    const partyTransactions = useMemo(
+        () => (activePartyId ? transactions.filter(tx => tx.party_id === activePartyId) : []),
+        [transactions, activePartyId]
+    );
 
     const handleAddNew = () => {
         setSelectedParty({});
@@ -114,9 +145,18 @@ const PartyMaster: React.FC = () => {
     
     return (
         <div className="space-y-8">
-            <div className="flex justify-between items-center">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <h1 className="text-3xl font-bold text-slate-800 dark:text-white">Parties Master</h1>
-                <button onClick={handleAddNew} className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 font-medium shadow-sm">Add New Party</button>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:space-x-3">
+                    <input
+                        type="text"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        placeholder="Search parties"
+                        className="w-full rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-slate-700 dark:border-slate-600"
+                    />
+                    <button onClick={handleAddNew} className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 font-medium shadow-sm">Add New Party</button>
+                </div>
             </div>
             <div className="bg-white dark:bg-slate-800 rounded-lg shadow-md">
                  <div className="overflow-x-auto">
@@ -133,21 +173,87 @@ const PartyMaster: React.FC = () => {
                         </thead>
                         <tbody>
                             {loading ? (<tr><td colSpan={6} className="text-center p-6">Loading parties...</td></tr>) :
-                             parties.map(party => (
-                                <tr key={party.id} className="border-b dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50">
+                             filteredParties.map(party => (
+                                <tr
+                                    key={party.id}
+                                    onClick={() => setActivePartyId(party.id)}
+                                    className={`border-b dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50 cursor-pointer ${activePartyId === party.id ? 'bg-indigo-50 dark:bg-slate-700/70' : ''}`}
+                                >
                                     <td className="p-4 font-medium">{party.name}</td>
                                     <td className="p-4">{party.type}</td>
                                     <td className="p-4">{party.mobile}</td>
                                     <td className="p-4 max-w-xs truncate">{party.address}</td>
                                     <td className="p-4 text-center">{party.tds_applicable ? `${party.tds_rate_percent}%` : 'No'}</td>
                                     <td className="p-4 text-center">
-                                        <button onClick={() => handleEdit(party)} className="text-indigo-500 hover:text-indigo-700 mr-2 p-1"><PencilIcon /></button>
-                                        <button onClick={() => handleDelete(party.id)} className="text-red-500 hover:text-red-700 p-1"><TrashIcon /></button>
+                                        <button onClick={(e) => { e.stopPropagation(); handleEdit(party); }} className="text-indigo-500 hover:text-indigo-700 mr-2 p-1"><PencilIcon /></button>
+                                        <button onClick={(e) => { e.stopPropagation(); handleDelete(party.id); }} className="text-red-500 hover:text-red-700 p-1"><TrashIcon /></button>
                                     </td>
                                 </tr>
                             ))}
                         </tbody>
                     </table>
+                </div>
+            </div>
+            <div className="bg-white dark:bg-slate-800 rounded-lg shadow-md">
+                <div className="border-b border-slate-200 dark:border-slate-700 px-4 py-3">
+                    <h2 className="text-xl font-semibold text-slate-800 dark:text-white">Transactions</h2>
+                    {activeParty && (
+                        <p className="text-sm text-slate-500 dark:text-slate-300">Showing transactions for {activeParty.name}</p>
+                    )}
+                </div>
+                <div className="overflow-x-auto">
+                    {activePartyId ? (
+                        partyTransactions.length > 0 ? (
+                            <table className="w-full text-left">
+                                <thead>
+                                    <tr className="bg-slate-50 dark:bg-slate-700 text-sm text-slate-600 dark:text-slate-300">
+                                        <th className="p-4 font-semibold">Date</th>
+                                        <th className="p-4 font-semibold">Bill No</th>
+                                        <th className="p-4 font-semibold">Type</th>
+                                        <th className="p-4 font-semibold text-right">Grand Total</th>
+                                        <th className="p-4 font-semibold text-right">Balance</th>
+                                        <th className="p-4 font-semibold text-center">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {partyTransactions.map(tx => {
+                                        const totals = calculateTransactionTotals(tx, chargeHeads, activeParty ?? undefined);
+                                        return (
+                                            <tr key={tx.id} className="border-b dark:border-slate-700">
+                                                <td className="p-4">{formatDate(tx.date)}</td>
+                                                <td className="p-4">{tx.bill_no}</td>
+                                                <td className="p-4">{tx.type}</td>
+                                                <td className="p-4 text-right">{formatINR(totals.grand_total)}</td>
+                                                <td className="p-4 text-right">{formatINR(totals.balance)}</td>
+                                                <td className="p-4 text-center space-x-2">
+                                                    <button
+                                                        onClick={() => navigate(`/voucher/edit/${tx.id}`)}
+                                                        className="text-indigo-500 hover:text-indigo-700"
+                                                    >
+                                                        Edit
+                                                    </button>
+                                                    <button
+                                                        onClick={() => {
+                                                            if (window.confirm('Are you sure you want to delete this transaction?')) {
+                                                                deleteTransaction(tx.id);
+                                                            }
+                                                        }}
+                                                        className="text-red-500 hover:text-red-700"
+                                                    >
+                                                        Delete
+                                                    </button>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        ) : (
+                            <div className="p-6 text-center text-slate-500 dark:text-slate-300">No transactions found for this party.</div>
+                        )
+                    ) : (
+                        <div className="p-6 text-center text-slate-500 dark:text-slate-300">Select a party to view transactions.</div>
+                    )}
                 </div>
             </div>
             {isModalOpen && <PartyModal party={selectedParty} onClose={() => setIsModalOpen(false)} onSave={saveParty} />}


### PR DESCRIPTION
## Summary
- add transaction deletion support to the data context
- extend the party master screen with search, selection, and a transaction panel
- integrate transaction totals formatting and navigation for edit/delete actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8e5c83024832585d4d7435be75e42