### PR TITLE
Add transaction PDF generation and download support

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -47,3 +47,7 @@ export const TrashIcon: React.FC = () => (
 export const PencilIcon: React.FC = () => (
   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L15.232 5.232z"></path></svg>
 );
+
+export const DocumentDownloadIcon: React.FC = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 11v6m0 0l3-3m-3 3l-3-3m6-4V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2h10a2 2 0 002-2v-7h-3z"></path></svg>
+);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.9.3"
+    "react-router-dom": "^7.9.3",
+    "jspdf": "^2.5.2",
+    "jspdf-autotable": "^3.8.2"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/pages/transactions/TransactionsDashboard.tsx
+++ b/pages/transactions/TransactionsDashboard.tsx
@@ -2,12 +2,13 @@ import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useData } from '../../hooks/useData';
 import { calculateTransactionTotals } from '../../services/calculationService';
+import { downloadTransactionPdf } from '../../services/transactionPdf';
 import { formatDate, formatINR } from '../../utils/formatters';
 import { TransactionType } from '../../types';
-import { PencilIcon, TrashIcon } from '../../components/Icons';
+import { DocumentDownloadIcon, PencilIcon, TrashIcon } from '../../components/Icons';
 
 const TransactionsDashboard: React.FC = () => {
-  const { transactions, parties, chargeHeads, deleteTransaction, loading } = useData();
+  const { transactions, parties, crops, chargeHeads, bankAccounts, deleteTransaction, loading } = useData();
   const navigate = useNavigate();
 
   const [selectedPartyId, setSelectedPartyId] = useState('');
@@ -179,6 +180,20 @@ const TransactionsDashboard: React.FC = () => {
                     <td className="p-4 text-right font-mono">{formatINR(totals.balance)}</td>
                     <td className="p-4">
                       <div className="flex justify-end gap-3">
+                        <button
+                          onClick={() =>
+                            downloadTransactionPdf(transaction, {
+                              parties,
+                              crops,
+                              chargeHeads,
+                              bankAccounts,
+                            })
+                          }
+                          className="p-2 rounded-md bg-emerald-50 dark:bg-emerald-600/20 text-emerald-600 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-600/40"
+                          title="Download PDF"
+                        >
+                          <DocumentDownloadIcon />
+                        </button>
                         <button
                           onClick={() => navigate(`/voucher/edit/${transaction.id}`)}
                           className="p-2 rounded-md bg-indigo-50 dark:bg-indigo-600/20 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-600/40"

--- a/services/transactionPdf.ts
+++ b/services/transactionPdf.ts
@@ -1,0 +1,246 @@
+import jsPDF from 'jspdf';
+import autoTable, { UserOptions } from 'jspdf-autotable';
+import {
+  BankAccount,
+  ChargeHead,
+  Crop,
+  Party,
+  Transaction,
+  TransactionType,
+} from '../types';
+import { calculateTransactionTotals } from './calculationService';
+import { amountToWords, formatDate, formatINR } from '../utils/formatters';
+
+interface TransactionPdfContext {
+  parties: Party[];
+  crops: Crop[];
+  chargeHeads: ChargeHead[];
+  bankAccounts: BankAccount[];
+}
+
+const FIRM_HEADER_LINES = [
+  'Virupaksheshwara Traders',
+  'No. 12, APMC Yard Road, Gangavathi - 583227, Koppal (KA)',
+  'Phone: +91 94480 12345 | Email: virupaksheshwaratraders@example.com',
+  'GSTIN: 29ABCDE1234F1Z5',
+];
+
+const MARGIN_X = 14;
+
+const renderTable = (doc: jsPDF, options: UserOptions): number => {
+  const table = autoTable(doc, options);
+  const finalY = (table as unknown as { finalY?: number }).finalY;
+  if (typeof finalY === 'number') {
+    return finalY;
+  }
+  const lastTable = (doc as unknown as { lastAutoTable?: { finalY: number } }).lastAutoTable;
+  return lastTable ? lastTable.finalY : (options.startY as number) ?? MARGIN_X;
+};
+
+const getCropName = (cropId: string, crops: Crop[]): string => {
+  const crop = crops.find(item => item.id === cropId);
+  if (!crop) return '—';
+  return crop.grade ? `${crop.name} (${crop.grade})` : crop.name;
+};
+
+const getBankAccountLabel = (bankAccountId: string | undefined, bankAccounts: BankAccount[]): string => {
+  if (!bankAccountId) return '—';
+  const account = bankAccounts.find(item => item.id === bankAccountId);
+  if (!account) return '—';
+  const parts = [account.bank_name, account.branch].filter(Boolean);
+  const header = parts.length > 0 ? parts.join(' - ') : account.bank_name;
+  const accountDetails = [`A/C ${account.account_no}`];
+  if (account.ifsc) {
+    accountDetails.push(`IFSC ${account.ifsc}`);
+  }
+  if (account.upi_id) {
+    accountDetails.push(`UPI ${account.upi_id}`);
+  }
+  return `${header}\n${accountDetails.join(' | ')}`;
+};
+
+export const downloadTransactionPdf = (
+  transaction: Transaction,
+  context: TransactionPdfContext,
+): void => {
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(16);
+  doc.text(FIRM_HEADER_LINES[0], MARGIN_X, 18);
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(10);
+  FIRM_HEADER_LINES.slice(1).forEach((line, index) => {
+    doc.text(line, MARGIN_X, 26 + index * 5);
+  });
+
+  const headerBottom = 26 + (FIRM_HEADER_LINES.length - 1) * 5;
+  doc.setDrawColor(180);
+  doc.line(MARGIN_X, headerBottom + 2, pageWidth - MARGIN_X, headerBottom + 2);
+
+  let currentY = headerBottom + 10;
+
+  const party = context.parties.find(item => item.id === transaction.party_id);
+  const broker = transaction.broker_id
+    ? context.parties.find(item => item.id === transaction.broker_id)
+    : undefined;
+  const bankAccountLabel = getBankAccountLabel(transaction.bank_account_id, context.bankAccounts);
+
+  const totals = calculateTransactionTotals(transaction, context.chargeHeads, party);
+
+  const metadataRows = [
+    ['Voucher type', transaction.type],
+    ['Voucher number', transaction.bill_no || '—'],
+    ['Voucher date', transaction.date ? formatDate(transaction.date) : '—'],
+    ['Party', party?.name ?? '—'],
+    ['Broker', broker?.name ?? '—'],
+    ['PO number', transaction.po_no || '—'],
+    ['Lorry number', transaction.lorry_no || '—'],
+    ['Bilty number', transaction.bilty_no || '—'],
+    ['Permit number', transaction.permit_no || '—'],
+    ['Destination', transaction.destination || '—'],
+    ['Payment terms', transaction.payment_terms || '—'],
+  ];
+
+  currentY = renderTable(doc, {
+    head: [['Field', 'Details']],
+    body: metadataRows,
+    startY: currentY,
+    theme: 'plain',
+    styles: { fontSize: 10, cellPadding: 2, textColor: '#1e293b' },
+    headStyles: { fontStyle: 'bold', textColor: '#0f172a' },
+    columnStyles: { 0: { fontStyle: 'bold', cellWidth: 45 } },
+  }) + 8;
+
+  if (transaction.lines.length > 0) {
+    const lineRows = transaction.lines.map((line, index) => {
+      const bags = line.bags === undefined || line.bags === null ? '—' : String(line.bags);
+      const netWeight =
+        line.net_weight_kg === undefined || line.net_weight_kg === null
+          ? '—'
+          : `${line.net_weight_kg.toFixed(2)} kg`;
+      const rateValue =
+        line.rate_value === undefined || line.rate_value === null
+          ? '—'
+          : `${line.rate_value.toFixed(2)} / ${line.rate_unit.replace('per_', '')}`;
+
+      return [
+        String(index + 1),
+        getCropName(line.crop_id, context.crops),
+        bags,
+        netWeight,
+        rateValue,
+        formatINR(line.line_amount ?? 0),
+      ];
+    });
+
+    currentY = renderTable(doc, {
+      head: [['#', 'Crop', 'Bags', 'Net weight', 'Rate', 'Amount']],
+      body: lineRows,
+      startY: currentY,
+      styles: { fontSize: 10, cellPadding: 2 },
+      headStyles: { fillColor: [15, 23, 42], textColor: 255 },
+      alternateRowStyles: { fillColor: [248, 250, 252] },
+      columnStyles: {
+        0: { halign: 'center', cellWidth: 10 },
+        2: { halign: 'right', cellWidth: 18 },
+        3: { halign: 'right', cellWidth: 28 },
+        4: { halign: 'right', cellWidth: 30 },
+        5: { halign: 'right', cellWidth: 30 },
+      },
+    }) + 8;
+  } else {
+    const paymentRows: string[][] = [
+      ['Voucher amount', formatINR(transaction.amount_received || 0)],
+      ['Payment terms', transaction.payment_terms || '—'],
+      ['Bank account / Cash details', bankAccountLabel],
+    ];
+
+    if (transaction.type === TransactionType.Payment) {
+      paymentRows.splice(1, 0, ['Payment type', transaction.payment_type ?? '—']);
+    }
+
+    if (transaction.type === TransactionType.Cash) {
+      paymentRows.push(['Purpose', transaction.cash_payment_purpose || '—']);
+      paymentRows.push(['Description', transaction.cash_description || '—']);
+    }
+
+    currentY = renderTable(doc, {
+      head: [['Payment details', '']],
+      body: paymentRows,
+      startY: currentY,
+      theme: 'plain',
+      styles: { fontSize: 10, cellPadding: 2, textColor: '#1e293b' },
+      headStyles: { fontStyle: 'bold', textColor: '#0f172a' },
+      columnStyles: { 0: { fontStyle: 'bold', cellWidth: 55 } },
+    }) + 8;
+  }
+
+  if (transaction.charges.length > 0) {
+    const chargeRows = transaction.charges.map(charge => {
+      const head = context.chargeHeads.find(item => item.id === charge.charge_head_id);
+      const name = head?.name ?? 'Charge';
+      const kind = head?.kind ?? '—';
+      const amount = charge.computed_amount ?? 0;
+      return [name, kind, formatINR(amount)];
+    });
+
+    currentY = renderTable(doc, {
+      head: [['Charge head', 'Kind', 'Amount']],
+      body: chargeRows,
+      startY: currentY,
+      styles: { fontSize: 10, cellPadding: 2 },
+      headStyles: { fillColor: [51, 65, 85], textColor: 255 },
+      columnStyles: {
+        1: { halign: 'center', cellWidth: 28 },
+        2: { halign: 'right', cellWidth: 30 },
+      },
+    }) + 8;
+  }
+
+  const amountReceivedLabel = transaction.type === TransactionType.Payment || transaction.type === TransactionType.Cash
+    ? 'Amount paid / received'
+    : 'Amount received';
+
+  const summaryRows = [
+    ['Subtotal', formatINR(totals.subtotal)],
+    ['Total additions', formatINR(totals.total_additions)],
+    ['Total deductions', formatINR(totals.total_deductions)],
+    ['Grand total', formatINR(totals.grand_total)],
+    [amountReceivedLabel, formatINR(transaction.amount_received)],
+    ['Balance', formatINR(totals.balance)],
+  ];
+
+  currentY = renderTable(doc, {
+    head: [['Summary', 'Amount']],
+    body: summaryRows,
+    startY: currentY,
+    theme: 'grid',
+    styles: { fontSize: 10, cellPadding: 2 },
+    headStyles: { fillColor: [30, 41, 59], textColor: 255 },
+    columnStyles: { 1: { halign: 'right', cellWidth: 40 } },
+  }) + 8;
+
+  const amountReference = transaction.lines.length > 0 ? totals.grand_total : transaction.amount_received;
+  const amountWords = amountToWords(amountReference);
+  const amountInWordsLabel = `Amount in words: ${amountWords || '—'}`;
+  const wrappedAmountLines = doc.splitTextToSize(amountInWordsLabel, pageWidth - MARGIN_X * 2);
+
+  doc.setFont('helvetica', 'italic');
+  doc.text(wrappedAmountLines, MARGIN_X, currentY);
+  currentY += wrappedAmountLines.length * 5;
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(11);
+  doc.text('Remarks', MARGIN_X, currentY + 6);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(10);
+  const remarksText = transaction.remarks?.trim() || '—';
+  const wrappedRemarks = doc.splitTextToSize(remarksText, pageWidth - MARGIN_X * 2);
+  doc.text(wrappedRemarks, MARGIN_X, currentY + 12);
+
+  const filename = `${transaction.bill_no || transaction.id || 'transaction'}-${transaction.date || 'voucher'}.pdf`;
+  doc.save(filename);
+};

--- a/utils/formatters.ts
+++ b/utils/formatters.ts
@@ -24,3 +24,134 @@ export const getTodayDateString = (): string => {
 export const formatWeight = (kg: number): string => {
     return `${kg.toFixed(2)} kg`;
 }
+
+const BELOW_TWENTY = [
+  'zero',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+  'thirteen',
+  'fourteen',
+  'fifteen',
+  'sixteen',
+  'seventeen',
+  'eighteen',
+  'nineteen',
+];
+
+const TENS = [
+  '',
+  '',
+  'twenty',
+  'thirty',
+  'forty',
+  'fifty',
+  'sixty',
+  'seventy',
+  'eighty',
+  'ninety',
+];
+
+const convertBelowThousand = (num: number): string => {
+  const words: string[] = [];
+
+  const hundreds = Math.floor(num / 100);
+  const remainder = num % 100;
+
+  if (hundreds > 0) {
+    words.push(`${BELOW_TWENTY[hundreds]} hundred`);
+  }
+
+  if (remainder > 0) {
+    if (remainder < 20) {
+      words.push(BELOW_TWENTY[remainder]);
+    } else {
+      const tensIndex = Math.floor(remainder / 10);
+      const units = remainder % 10;
+      if (units > 0) {
+        words.push(`${TENS[tensIndex]}-${BELOW_TWENTY[units]}`);
+      } else {
+        words.push(TENS[tensIndex]);
+      }
+    }
+  }
+
+  return words.join(' ');
+};
+
+const convertNumberToWords = (num: number): string => {
+  if (num === 0) return BELOW_TWENTY[0];
+
+  const segments: string[] = [];
+
+  const crore = Math.floor(num / 10000000);
+  if (crore > 0) {
+    segments.push(`${convertNumberToWords(crore)} crore`);
+    num %= 10000000;
+  }
+
+  const lakh = Math.floor(num / 100000);
+  if (lakh > 0) {
+    segments.push(`${convertNumberToWords(lakh)} lakh`);
+    num %= 100000;
+  }
+
+  const thousand = Math.floor(num / 1000);
+  if (thousand > 0) {
+    segments.push(`${convertNumberToWords(thousand)} thousand`);
+    num %= 1000;
+  }
+
+  if (num > 0) {
+    segments.push(convertBelowThousand(num));
+  }
+
+  return segments.join(' ');
+};
+
+export const amountToWords = (amount: number): string => {
+  if (amount === undefined || amount === null || Number.isNaN(amount)) {
+    return '';
+  }
+
+  const isNegative = amount < 0;
+  const absoluteAmount = Math.abs(amount);
+
+  const rupees = Math.floor(absoluteAmount);
+  const paise = Math.round((absoluteAmount - rupees) * 100);
+
+  const rupeeLabel = rupees === 1 ? 'rupee' : 'rupees';
+  const paiseLabel = 'paise';
+
+  let sentence = '';
+
+  if (rupees > 0) {
+    sentence = `${rupeeLabel} ${convertNumberToWords(rupees)}`;
+  } else if (paise > 0) {
+    sentence = `${rupeeLabel} zero`;
+  } else {
+    sentence = `${rupeeLabel} zero`;
+  }
+
+  if (paise > 0) {
+    sentence = `${sentence} and ${convertNumberToWords(paise)} ${paiseLabel}`;
+  }
+
+  sentence = `${sentence} only`;
+
+  if (isNegative) {
+    sentence = `minus ${sentence}`;
+  }
+
+  const normalized = sentence.replace(/\s+/g, ' ').trim().toLowerCase();
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};


### PR DESCRIPTION
## Summary
- add jsPDF and autoTable dependencies for client-side PDF creation
- extend the formatter utilities with an INR-friendly amount-to-words helper
- implement a transaction PDF generator and expose it via a download button in the dashboard

## Testing
- `npm install` *(fails: 403 Forbidden when fetching jspdf)*

------
https://chatgpt.com/codex/tasks/task_b_68d8f0ecceec83259be9b28bf2a434c8