### PR TITLE
Handle missing jsPDF dependencies gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
       }
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.1/jspdf.plugin.autotable.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <style>
       /* Hide number input arrows */


### PR DESCRIPTION
## Summary
- guard the PDF export workflow against missing jsPDF and autoTable dependencies
- register jsPDF autoTable plugin via CDN so it is available before React loads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d8f7e065c483258916b93af2dfae57