### PR TITLE
Add jsPDF AutoTable plugin to Party Ledger export

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
       }
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.2/jspdf.plugin.autotable.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <style>
       /* Hide number input arrows */

--- a/pages/reports/PartyLedgerReport.tsx
+++ b/pages/reports/PartyLedgerReport.tsx
@@ -86,6 +86,12 @@ const PartyLedgerReport: React.FC = () => {
         const doc = new jsPDF();
         const selectedParty = parties.find(p => p.id === selectedPartyId);
 
+        if (typeof doc.autoTable !== 'function') {
+            window?.alert?.('PDF export is currently unavailable. Please try again later.');
+            console.error('jsPDF autoTable plugin is not loaded.');
+            return;
+        }
+
         doc.setFontSize(18);
         doc.text(`Ledger for ${selectedParty?.name || 'N/A'}`, 14, 22);
         


### PR DESCRIPTION
## Summary
- include the jsPDF AutoTable CDN script so the plugin is available to the React bundle
- add a defensive alert in the Party Ledger PDF export to surface missing plugin errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dccdcb585c8325a3fab5d3e09bf546