### PR TITLE
Handle purchase-like vouchers in totals

### DIFF
--- a/services/calculationService.ts
+++ b/services/calculationService.ts
@@ -105,8 +105,14 @@ export const calculateTransactionTotals = (
         }
     });
 
-    const grand_total = transaction.type === TransactionType.Purchase
-        ? subtotal + total_additions + total_deductions // For purchase, expenses (deductions) are added to cost
+    const isPurchaseLike = [
+        TransactionType.Purchase,
+        TransactionType.Asami,
+        TransactionType.ZeroDalal,
+    ].includes(transaction.type);
+
+    const grand_total = isPurchaseLike
+        ? subtotal + total_additions + total_deductions // For purchase-style vouchers, expenses (deductions) are added to cost
         : subtotal + total_additions - total_deductions; // For sale, deductions are subtracted
 
     const balance = grand_total - transaction.amount_received;


### PR DESCRIPTION
## Summary
- treat Asami and Zero Dalal vouchers like purchases when computing the grand total
- add a purchase-like flag to reuse the same logic across all relevant voucher types

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dccf41e5888325a90ed5ebd0f77a17