### PR TITLE
Add PDF export for individual vouchers

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -47,3 +47,20 @@ export const TrashIcon: React.FC = () => (
 export const PencilIcon: React.FC = () => (
   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L15.232 5.232z"></path></svg>
 );
+
+export const DownloadIcon: React.FC = () => (
+  <svg
+    className="w-5 h-5"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5m0 0l5-5m-5 5V4"
+    ></path>
+  </svg>
+);

--- a/pages/transactions/TransactionsDashboard.tsx
+++ b/pages/transactions/TransactionsDashboard.tsx
@@ -3,11 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { useData } from '../../hooks/useData';
 import { calculateTransactionTotals } from '../../services/calculationService';
 import { formatDate, formatINR } from '../../utils/formatters';
-import { TransactionType } from '../../types';
-import { PencilIcon, TrashIcon } from '../../components/Icons';
+import { Transaction, TransactionType } from '../../types';
+import { exportVoucherPDF } from '../../services/voucherPdfService';
+import { DownloadIcon, PencilIcon, TrashIcon } from '../../components/Icons';
 
 const TransactionsDashboard: React.FC = () => {
-  const { transactions, parties, chargeHeads, deleteTransaction, loading } = useData();
+  const { transactions, parties, chargeHeads, crops, bankAccounts, deleteTransaction, loading } = useData();
   const navigate = useNavigate();
 
   const [selectedPartyId, setSelectedPartyId] = useState('');
@@ -57,6 +58,10 @@ const TransactionsDashboard: React.FC = () => {
     if (window.confirm(`Delete voucher ${transaction?.bill_no || ''}${partyName ? ` for ${partyName}` : ''}?`)) {
       deleteTransaction(transactionId);
     }
+  };
+
+  const handleExport = (transaction: Transaction) => {
+    exportVoucherPDF(transaction, { parties, chargeHeads, crops, bankAccounts });
   };
 
   if (loading) {
@@ -179,6 +184,13 @@ const TransactionsDashboard: React.FC = () => {
                     <td className="p-4 text-right font-mono">{formatINR(totals.balance)}</td>
                     <td className="p-4">
                       <div className="flex justify-end gap-3">
+                        <button
+                          onClick={() => handleExport(transaction)}
+                          className="p-2 rounded-md bg-emerald-50 dark:bg-emerald-600/20 text-emerald-600 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-600/40"
+                          title="Download Voucher PDF"
+                        >
+                          <DownloadIcon />
+                        </button>
                         <button
                           onClick={() => navigate(`/voucher/edit/${transaction.id}`)}
                           className="p-2 rounded-md bg-indigo-50 dark:bg-indigo-600/20 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-600/40"

--- a/services/voucherPdfService.ts
+++ b/services/voucherPdfService.ts
@@ -1,0 +1,234 @@
+import { BankAccount, ChargeHead, ChargeKind, Crop, Party, PaymentType, Transaction, TransactionType } from '../types';
+import { calculateTransactionTotals } from './calculationService';
+import { formatDate, formatINR } from '../utils/formatters';
+
+const JsPDFConstructor = typeof window !== 'undefined' ? (window as any)?.jspdf?.jsPDF : undefined;
+
+interface VoucherPdfContext {
+  parties: Party[];
+  chargeHeads: ChargeHead[];
+  crops: Crop[];
+  bankAccounts: BankAccount[];
+}
+
+const toTitleCase = (value?: string | null): string => {
+  if (!value) return '—';
+  return value
+    .split(' ')
+    .map(word => (word ? word[0].toUpperCase() + word.slice(1).toLowerCase() : ''))
+    .join(' ');
+};
+
+const getBankLabel = (bankAccount?: BankAccount): string => {
+  if (!bankAccount) return '—';
+  const parts = [bankAccount.bank_name, bankAccount.branch].filter(Boolean);
+  return parts.join(' – ');
+};
+
+export const exportVoucherPDF = (
+  transaction: Transaction,
+  context: VoucherPdfContext
+) => {
+  const JsPDF = JsPDFConstructor ?? (typeof window !== 'undefined' ? (window as any)?.jspdf?.jsPDF : undefined);
+
+  if (typeof JsPDF !== 'function') {
+    window?.alert?.('PDF export is currently unavailable. Please try again later.');
+    console.error('jsPDF constructor is not available.');
+    return;
+  }
+
+  const doc = new JsPDF();
+
+  if (typeof (doc as any).autoTable !== 'function') {
+    window?.alert?.('PDF export is currently unavailable. Please try again later.');
+    console.error('jsPDF autoTable plugin is not loaded.');
+    return;
+  }
+
+  const { parties, chargeHeads, crops, bankAccounts } = context;
+  const party = parties.find(p => p.id === transaction.party_id);
+  const broker = transaction.broker_id ? parties.find(p => p.id === transaction.broker_id) : undefined;
+  const bankAccount = transaction.bank_account_id
+    ? bankAccounts.find(account => account.id === transaction.bank_account_id)
+    : undefined;
+  const totals = calculateTransactionTotals(transaction, chargeHeads, party);
+  const pageWidth = doc.internal.pageSize.getWidth();
+
+  doc.setFontSize(16);
+  doc.text(`${transaction.type} Voucher`, 14, 18);
+
+  doc.setFontSize(10);
+  doc.text(`Bill No: ${transaction.bill_no || '—'}`, 14, 26);
+  doc.text(`Date: ${formatDate(transaction.date) || '—'}`, pageWidth - 14, 26, { align: 'right' });
+
+  let cursorY = 36;
+  doc.setFont(undefined, 'bold');
+  doc.text('Party Details', 14, cursorY);
+  doc.setFont(undefined, 'normal');
+  cursorY += 6;
+
+  const partyDetails: string[] = [
+    `Name: ${party?.name || '—'}`,
+    `Address: ${party?.address || '—'}`,
+    `Mobile: ${party?.mobile || '—'}`,
+  ];
+
+  if (party?.gstin) {
+    partyDetails.push(`GSTIN: ${party.gstin}`);
+  }
+
+  partyDetails.forEach(line => {
+    doc.text(line, 14, cursorY);
+    cursorY += 5;
+  });
+
+  if (broker) {
+    doc.text(`Broker: ${broker.name}`, 14, cursorY);
+    cursorY += 5;
+  }
+
+  if (transaction.destination) {
+    doc.text(`Destination: ${transaction.destination}`, 14, cursorY);
+    cursorY += 5;
+  }
+
+  if (transaction.remarks) {
+    doc.text(`Remarks: ${transaction.remarks}`, 14, cursorY);
+    cursorY += 5;
+  }
+
+  if (transaction.type === TransactionType.Payment) {
+    cursorY += 3;
+    doc.setFont(undefined, 'bold');
+    doc.text('Payment Details', 14, cursorY);
+    doc.setFont(undefined, 'normal');
+    cursorY += 6;
+
+    const paymentLines = [
+      `Payment Type: ${transaction.payment_type ? toTitleCase(transaction.payment_type) : '—'}`,
+      `Amount: ${formatINR(transaction.amount_received)}`,
+      `Mode: ${bankAccount ? 'Bank Transfer' : 'Cash'}`,
+    ];
+
+    if (bankAccount) {
+      paymentLines.push(`Bank: ${getBankLabel(bankAccount)}`);
+      paymentLines.push(`Account No: ${bankAccount.account_no}`);
+      if (bankAccount.ifsc) {
+        paymentLines.push(`IFSC: ${bankAccount.ifsc}`);
+      }
+    }
+
+    paymentLines.forEach(line => {
+      doc.text(line, 14, cursorY);
+      cursorY += 5;
+    });
+  } else if (transaction.type === TransactionType.Cash) {
+    cursorY += 3;
+    doc.setFont(undefined, 'bold');
+    doc.text('Cash Payment Details', 14, cursorY);
+    doc.setFont(undefined, 'normal');
+    cursorY += 6;
+
+    const cashLines = [
+      `Purpose: ${toTitleCase(transaction.cash_payment_purpose)}`,
+      `Amount: ${formatINR(transaction.amount_received)}`,
+    ];
+
+    if (transaction.cash_description) {
+      cashLines.push(`Description: ${transaction.cash_description}`);
+    }
+
+    cashLines.forEach(line => {
+      doc.text(line, 14, cursorY);
+      cursorY += 5;
+    });
+  }
+
+  const isLineVoucher = transaction.lines.length > 0;
+  if (isLineVoucher) {
+    cursorY += 4;
+    (doc as any).autoTable({
+      startY: cursorY,
+      head: [['Item', 'Bags', 'Net Wt (kg)', 'Rate', 'Amount']],
+      body: transaction.lines.map(line => {
+        const crop = crops.find(c => c.id === line.crop_id);
+        const rateLabel = `${formatINR(line.rate_value)} / ${line.rate_unit.replace('per_', '').replace('_', ' ')}`;
+        return [
+          crop?.name || '—',
+          line.bags,
+          line.net_weight_kg.toFixed(2),
+          rateLabel,
+          formatINR(line.line_amount),
+        ];
+      }),
+      styles: { fontSize: 9 },
+      columnStyles: {
+        0: { halign: 'left' },
+        1: { halign: 'right' },
+        2: { halign: 'right' },
+        3: { halign: 'right' },
+        4: { halign: 'right' },
+      },
+    });
+    cursorY = (doc as any).lastAutoTable.finalY + 8;
+  }
+
+  if (transaction.charges.length > 0) {
+    (doc as any).autoTable({
+      startY: cursorY,
+      head: [['Charge', 'Type', 'Amount']],
+      body: transaction.charges.map(charge => {
+        const head = chargeHeads.find(h => h.id === charge.charge_head_id);
+        const typeLabel = head?.kind === ChargeKind.Addition ? 'Addition' : 'Deduction';
+        return [
+          head?.name || '—',
+          typeLabel,
+          formatINR(charge.computed_amount || 0),
+        ];
+      }),
+      styles: { fontSize: 9 },
+      columnStyles: {
+        0: { halign: 'left' },
+        1: { halign: 'left' },
+        2: { halign: 'right' },
+      },
+    });
+    cursorY = (doc as any).lastAutoTable.finalY + 8;
+  }
+
+  const summaryRows: Array<[string, string]> = [];
+
+  if (isLineVoucher) {
+    summaryRows.push(['Subtotal', formatINR(totals.subtotal)]);
+    summaryRows.push(['Total Additions', formatINR(totals.total_additions)]);
+    summaryRows.push(['Total Deductions', formatINR(totals.total_deductions)]);
+    summaryRows.push(['Grand Total', formatINR(totals.grand_total)]);
+    summaryRows.push(['Amount Received', formatINR(transaction.amount_received)]);
+    summaryRows.push(['Balance', formatINR(totals.balance)]);
+  } else if (transaction.type === TransactionType.Payment) {
+    summaryRows.push(['Payment Type', transaction.payment_type ? toTitleCase(transaction.payment_type) : '—']);
+    summaryRows.push(['Amount', formatINR(transaction.amount_received)]);
+    summaryRows.push(['Balance Impact', transaction.payment_type === PaymentType.Paid ? formatINR(transaction.amount_received) : formatINR(-transaction.amount_received)]);
+  } else if (transaction.type === TransactionType.Cash) {
+    summaryRows.push(['Amount', formatINR(transaction.amount_received)]);
+    if (transaction.cash_payment_purpose) {
+      summaryRows.push(['Purpose', toTitleCase(transaction.cash_payment_purpose)]);
+    }
+  }
+
+  if (summaryRows.length > 0) {
+    (doc as any).autoTable({
+      startY: cursorY,
+      body: summaryRows.map(row => [row[0], row[1]]),
+      theme: 'plain',
+      styles: { fontSize: 10, halign: 'right' },
+      columnStyles: {
+        0: { halign: 'left' },
+        1: { halign: 'right' },
+      },
+    });
+    cursorY = (doc as any).lastAutoTable.finalY + 8;
+  }
+
+  doc.save(`${transaction.bill_no || transaction.id}.pdf`);
+};


### PR DESCRIPTION
## Summary
- add a reusable voucher PDF exporter that renders line items, charges, and payment details
- surface a download button on the transactions dashboard for quick voucher exports, including payments
- add a download icon asset for the new action button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dce7851364832592a37d7a70f2e8df