### PR TITLE
Fix INR formatting to remove spacing in PDF exports

### DIFF
--- a/utils/formatters.ts
+++ b/utils/formatters.ts
@@ -1,11 +1,13 @@
 
 export const formatINR = (amount: number): string => {
-  return new Intl.NumberFormat('en-IN', {
-    style: 'currency',
-    currency: 'INR',
+  const formatter = new Intl.NumberFormat('en-IN', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
-  }).format(amount);
+  });
+
+  const isNegative = amount < 0;
+  const formattedNumber = formatter.format(Math.abs(amount));
+  return `${isNegative ? '-' : ''}₹${formattedNumber}`;
 };
 
 export const formatDate = (dateString: string): string => {


### PR DESCRIPTION
## Summary
- adjust the INR formatter to build the currency string manually, removing the non-breaking space that jsPDF was rendering as extra spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dcf263853483258a95b0ed9ecd2148